### PR TITLE
Enable input of hex string

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -3,6 +3,12 @@ import ProtoDisplay from './ProtoDisplay.jsx'
 import ErrorBoundary from './ErrorBoundary.jsx'
 import Reader from 'rawproto'
 
+const isHex = (maybeHex) =>
+  maybeHex.length !== 0 && maybeHex.length % 2 === 0 && !/[^a-fA-F0-9]/u.test(maybeHex);
+
+const fromHexString = (hexString) =>
+  Uint8Array.from(hexString.match(/.{1,2}/g).map((byte) => parseInt(byte, 16)));
+
 function App() {
   const [fields, setFields] = useState([])
 
@@ -15,6 +21,15 @@ function App() {
     }
   }
 
+  const handleHexChange = async (e) => {
+    const input = e.target.value.replaceAll(" ", "")
+    if (isHex(input)) {
+      const decoded = fromHexString(input)
+      const tree = new Reader(decoded).readMessage()
+      setFields(tree)
+    }
+  }
+
   return (
     <div className='flex flex-col h-screen'>
       <header className='p-4 h-16 flex'>
@@ -23,6 +38,7 @@ function App() {
       <main className='p-4 grow overflow-y-auto'>
         {!fields?.length && <p className='mb-2'>Choose a binary protobuf file, and you can explore it. No data is sent to any server (all local.)</p>}
         <input type='file' className='mb-2 w-full file-input' onChange={handleFileChange} />
+        <input type='text' className='mb-2 w-full border-2 px-5' placeholder="Hex string input" onChange={handleHexChange} />
         <ErrorBoundary>
           <ProtoDisplay className='w-full menu bg-base-200 rounded-box' fields={fields} />
         </ErrorBoundary>


### PR DESCRIPTION
Enables the input of hex strings to decode protobufs as writing to a file is not always the easiest option.

![image](https://github.com/konsumer/rawproto/assets/25753391/7d8e276f-8d64-4a7f-991e-4c8395a73008)
