### PR TITLE
UI Visual Improvements

### DIFF
--- a/ui/src/ProtoDisplay.jsx
+++ b/ui/src/ProtoDisplay.jsx
@@ -29,6 +29,7 @@ function ProtoField(field) {
       <details>
         <summary>
           <div className={`badge badge-${badgeColors[field.type]} gap-2`}>{field.index}</div>
+          <p className="text-gray-500 italic">{parseLabels[field.renderType]}</p>
         </summary>
         <ProtoDisplay fields={sub} />
       </details>
@@ -38,7 +39,16 @@ function ProtoField(field) {
   return (
     <div>
       <div className={`badge badge-${badgeColors[field.type]} gap-2`}>{field.index}</div>
-      <Linkify>{decoders.display(field)}</Linkify>
+      <Linkify>
+        <div className="flex w-full justify-between">
+          <p>
+            {decoders.display(field)}
+          </p>
+          <p>
+            {`${wireLabels[field.type]} as ${parseLabels[field.renderType]}`}
+          </p>
+        </div>
+      </Linkify>
     </div>
   )
 }


### PR DESCRIPTION
Previously the only way to know a field's type was to hover over its field number. I have placed the field type on the right side of the row so its easier to see.

I have also indicated if a field is a sub message as well.

![image](https://github.com/konsumer/rawproto/assets/25753391/2f101157-ff2c-4271-b46d-258fd3744037)
